### PR TITLE
Typed evaluation contexts

### DIFF
--- a/sn-proof/sn-proof.tex
+++ b/sn-proof/sn-proof.tex
@@ -100,6 +100,9 @@
 
 \newcommand{\nf}[2]{#1 : #2 ~\mathsf{nf}}
 \newcommand{\neu}[2]{#1 : #2 ~\mathsf{ne}}
+\newcommand{\hole}{\mathsf{\_}}
+\newcommand{\holetype}{\mathsf{~|~}}
+
 
  \newcommand{\one}{1}
 \newcommand{\SN}{\mathsf{SN}}
@@ -652,7 +655,12 @@ Let us begin by contrasting weak and strong normalization. A term $M$ is said to
 
 As pointed out by \cite{Raamsdonk_onnormalisation}, we can easily characterize all weakly normalising terms as follows: a  weakly normalising term is a normal form or can be obtained as the result of some expansion starting in a  normal form. Following this idea, we can then characterize elegantly strongly normalizing terms also as the closure under expansion where expansion is subject to two restrictions: first, the argument of the redex introduced by the expansion step should be in the set of strongly normalising terms, and second, the expansion step should yield a new head redex (backwards closure) or a  new outermost redex in a  term without a  head redex. This idea will form the essence of the closure properties we state next and also gives rise to an inductive definition of strongly normalizing terms which we give in the next section.
 
-To compactly state closure properties and congruence rules, we rely on evaluation contexts which we define below:
+\subsubsection{Typed Evaluation Contexts}
+
+To compactly state closure properties and congruence rules, we rely on
+evaluation contexts. An evaluation context is a term with a hole, written
+as $\hole$. They are inductively defined: they are either a hole or built
+by $C~M$ where $C$ is a smaller evaluation context containing a hole:
 
 \[
 \begin{array}{lcl}
@@ -660,12 +668,113 @@ To compactly state closure properties and congruence rules, we rely on evaluatio
 \end{array}
 \]
 
-An evaluation context is a term with a hole, written as an underscore.
 
 Using evaluation contexts, we can describe the term $x~M_1 \ldots M_n$ using the evaluation context $C = \_~M_1 \ldots M_n$ and simply instantiate the hole with $x$ writing $C[x]$ for $x~M_1 \ldots M_n$. We can also represent the term $x~M_1 \ldots M_n$ choosing the evaluation context $C' = \_~M_1 \ldots M_{n-1}$ writing $C'[x]~M_n = C[x]$.
 
 Similarly, choosing $C = \_ ~N_1 \ldots N_k$ and instantiating the hole with $\lambda x{:}A.M$ we describe a term $C[\lambda x{:}A.M] = (\lambda x{:}A.M)~N_1 \ldots N_k$ which has a redex. Moreover, when choosing the evaluation context $C' = \_~N_2 \ldots N_k$ we have $C'[(\lambda x{:}A.M)~N_1] = C[\lambda x{:}A.M]$.
 
+\begin{definition}[Typing Rules for Evaluation Contexts]\label{def:ectx}
+We write $\Gamma \holetype \alpha \vdash C : A$ to state that the evaluation context
+$C$ lives in scope $\Gamma$, has a hole of type $\alpha$ and gives rise to an overall
+expression of type $A$. This relation is specified by the two following typing rules:
+\[
+\begin{array}{c}
+\infer{\Gamma \holetype \alpha \vdash \hole : \alpha}{}
+\qquad
+\infer{\Gamma \holetype \alpha \vdash C\,M : B}{{\Gamma \holetype \alpha \vdash C : A \arrow B} & {\Gamma \vdash M : A}}
+\end{array}
+\]
+\end{definition}
+
+\begin{lemma}[Properties of Typed Evaluation Contexts]\label{lm:pectx}$\;$
+\begin{enumerate}
+  \item If $\Gamma \holetype \alpha \vdash C : A$ and $\Gamma \vdash M : \alpha$ then $\Gamma \vdash C[M] : A$.
+  \item If $\Gamma \holetype \beta \vdash C : A$ and $\Gamma \holetype \alpha \vdash C' : \beta$ then
+        $\Gamma \holetype \alpha \vdash C \circ C' : A$
+  \item If $\Gamma \holetype \alpha \vdash C : A$ and $\Gamma \vdash M \red N : \alpha$ then
+        $\Gamma \vdash C[M] \red C[N] : A$
+\end{enumerate}
+\end{lemma}
+\begin{proof}
+  All of the proofs are by induction on $\Gamma \holetype \alpha \vdash C : A$.
+\end{proof}
+
+\begin{definition}[Strongly Normalizing Evaluation Contexts]\label{def:snectx} We can inductively
+define what it means for an evaluation context to be built of terms which are
+$\csn$ like so:
+\[
+\begin{array}{c}
+\infer{\Gamma \holetype \alpha \vdash \hole : \alpha \in \csn}{}
+\qquad
+\infer{\Gamma \holetype \alpha \vdash C\,M : B \in \csn}{{\Gamma \holetype \alpha \vdash C : A \arrow B \in \csn} & {\Gamma \vdash M : A \in \csn}}
+\end{array}
+\]
+\end{definition}
+
+\begin{lemma}[Properties of Strongly Normalizing Evaluation Contexts]\label{lm:psnectx}$\;$
+  \begin{enumerate}
+  \item If $\Gamma \holetype \alpha \vdash C : A \in \csn$ and $x : A \in \Gamma$
+    then $\Gamma \vdash C[x] : A \in \csn$
+  \item If $\Gamma \holetype \beta \vdash C : A \in \csn$
+    and $\Gamma \holetype \alpha \vdash C' : \beta \in \csn$
+    then $\Gamma \holetype \alpha \vdash C \circ C' : A \in \csn$
+  \item If $\Gamma \vdash C[M] : A \in \csn$ then $\Gamma \holetype \alpha \vdash C : A \in \csn$
+    and $\Gamma \vdash M : \alpha \in \csn$
+  \end{enumerate}
+\end{lemma}
+\begin{proof}
+  The proof are by structural induction on $C$.
+\end{proof}
+
+\begin{lemma}[Inversion of Reduction involving an Evaluation Context]\label{lm:invrectx}$\;$
+Assuming that $\Gamma \holetype \alpha \vdash C : A \in \csn$, $\Gamma \vdash M : \alpha$, $M$
+is not $\lambda$-headed and $\Gamma \vdash P : A$, if $\Gamma \vdash C[M] \red P : A$ then
+\begin{itemize}
+  \item Either $\exists M'$ s.t. $P = C[M']$ and $\Gamma \vdash M \red M' : \alpha$
+  \item Or $\exists D$ s.t. $P = D[M]$, $\Gamma \holetype \alpha \vdash D : A \in \csn$
+           and $\forall N. \Gamma \vdash C[N] \red D[N] : A$
+\end{itemize}
+\end{lemma}
+\begin{proof}By induction on $\Gamma \holetype \alpha \vdash C : A \in \csn$
+
+\paragraph{Case} $C = \_$\\[1em]
+$\Gamma \vdash M \red P : A$ \hfill by assumption and $C = \hole$\\
+Therefore $\exists M'$ s.t. $P = C[M']$ and $\Gamma \vdash M \red M' : \alpha$ \hfill pick $M' = P$
+
+\paragraph{Case} $C = C'\,T$ where $\Gamma \vdash T : B \in \csn$\\[1em]
+$\Gamma \vdash C'[M]\,T \red P$ \hfill by assumption and $C=C'\,T$
+\\[1em]
+\textbf{Sub-case} $\ianc{\Gamma \vdash T \red T' : B}{\Gamma \vdash C'[M]\,T \red C'[M]\,T' : A}{}$
+\\[1em]
+$P = C'[M]\,T'$ \hfill by assumption\\
+$\Gamma \vdash T' : B \in \csn$ \hfill by $\Gamma \vdash T : B \in \csn$ and $\Gamma \vdash T \red T' : B$\\
+$\Gamma \holetype \alpha \vdash C'\,T' : A \in \csn$ \hfill since $\Gamma \holetype \alpha \vdash C' : B \arrow A \in \csn$\\
+$\forall N. \Gamma \vdash C'[N]\,T \red C'[N]\,T' : A$ \hfill because $\Gamma \vdash T \red T' : B$\\
+Therefore $\exists D$ s.t. $P = D[M]$, $\Gamma \holetype \alpha \vdash D : A \in \csn$
+     and $\forall N. \Gamma \vdash C'[N]\,T \red D[N] : A$ \hfill pick $D = C'\,T'$
+\\[1em]
+\textbf{Sub-case} $\ianc{\Gamma \vdash C'[M] \red P_0 : B \arrow A}{\Gamma \vdash C'[M]\,T \red P_0\,T : A}{}$
+\\[1em]
+Either $\exists M'$ s.t. $P_0 = C'[M']$ and $\Gamma \vdash M \red M' : \alpha$ \hfill by IH\\
+Or $\exists D$ s.t. $P_0 = D[M]$, $\Gamma \holetype \alpha \vdash D : B \arrow A \in \csn$
+           and $\forall N. \Gamma \vdash C'[N] \red D[N] : A$
+\\[1em]
+\textbf{Sub-case} $\exists M'$ s.t. $P_0 = C'[M']$ and $\Gamma \vdash M \red M' : \alpha$
+\\[1em]
+$P = C'[M']\,T$ \hfill because $P = P_0\,T$ and $P_0 = C'[M']$\\
+Then $\exists M'$ s.t. $P_0\,T = C'[M']\,T$ and $\Gamma \vdash M \red M' : \alpha$ \hfill pick the same $M'$
+\\[1em]
+\textbf{Sub-case} $\exists D$ s.t. $P_0 = D[M]$, $\Gamma \holetype \alpha \vdash D : B \arrow A \in \csn$
+           and $\forall N. \Gamma \vdash C[N] \red D[N] : A$
+\\[1em]
+$\Gamma \holetype \alpha \vdash D\,T : A \in \csn$ \hfill by combining assumptions\\
+$\forall N. \Gamma \vdash C'[N]\,T \red D[N]\,T : A$ \hfill because $\forall N. \Gamma \vdash C'[N] \red D[N] : B \arrow A$\\
+Then $\exists D'$ s.t. $P_0\,T = D'[M]$, $\Gamma \holetype \alpha \vdash D' : A \in \csn$
+and $\forall N. \Gamma \vdash C'[N]\,T \red D'[N] : A$ \hfill pick $D' = D\,T$
+\\[1em]
+\textbf{Sub-case} $\beta$-reduction impossible because $M$ is not $\lambda$-headed by assumption
+
+\end{proof}
 
 % Then we only have one reduction rule for evaluation contexts
 
@@ -678,14 +787,12 @@ Similarly, choosing $C = \_ ~N_1 \ldots N_k$ and instantiating the hole with $\l
 
 % where $M$ is the sub-term that we reduce.
 
-Evaluation contexts are inductively defined -- they are either a hole or built by $C~M$ where $C$ is a smaller evaluation context containing a hole.
-
 \begin{lemma}[Multi-step Reductions with Evaluation Contexts]\label{lm:mredecxt}
-If $\Gamma \vdash M \mred N : B$ and $\Gamma, x{:}B \vdash C[x] : B'$
-then $\Gamma \vdash C[M] \mred C[N] : B'$.  
+If $\Gamma \vdash M \mred N : \alpha$ and $\Gamma \holetype \alpha \vdash C : B$
+then $\Gamma \vdash C[M] \mred C[N] : B$.
 \end{lemma}
 \begin{proof}
-By induction on the structure of $C$.  
+By induction on $\Gamma \vdash M \mred N : \alpha$ and Lemma \ref{lm:pectx} (3).
 \end{proof}
 
 \begin{lemma}[Evaluation Contexts]\label{lm:ecxt}$\;$
@@ -864,115 +971,94 @@ $\Gamma \vdash x : A \in \csn$
 \end{proof}
 
 
-\begin{lemma}[Composition of Evaluation Contexts]\label{lm:compecxt}\quad\\
-If $\Gamma, x{:}A \vdash C[x] : B \in \csn$ 
-and $\Gamma, y{:}A' \vdash C'[y]: A \in \csn$
-then $\Gamma, y{:}A' \vdash C[C'[y]] : B \in \csn$.  
-\end{lemma}
-\begin{proof}
-Induction on the structure of evaluation context $C$.
+% \begin{lemma}[Composition of Evaluation Contexts]\label{lm:compecxt}\quad\\
+% If $\Gamma, x{:}A \vdash C[x] : B \in \csn$ 
+% and $\Gamma, y{:}A' \vdash C'[y]: A \in \csn$
+% then $\Gamma, y{:}A' \vdash C[C'[y]] : B \in \csn$.  
+% \end{lemma}
+% \begin{proof}
+% Induction on the structure of evaluation context $C$.
 
-\paragraph{Case} $C = \underline{\quad}$
-\\
-$\Gamma, y{:}A' \vdash C'[y] : A \in \csn$ \hfill by assumption 
+%% \paragraph{Case} $C = \underline{\quad}$
+%% \\
+%% $\Gamma, y{:}A' \vdash C'[y] : A \in \csn$ \hfill by assumption 
 
-\paragraph{Case} $C = C_1[x]~[\rho]M$ s.t. $\Gamma, x{:}A \vdash  C_1[x]~M : B$ where $\Gamma \vdash M : B'$ and $\Gamma, x{:}A \ext{\rho} \Gamma$.
-\\[0.5em]
-Assume $\Gamma, y{:}A' \vdash C_1[C'[y]]~[\rho']M \red Q : B$ where $\Gamma, y{:}A' \ext{\rho'} \Gamma$.
+%% \paragraph{Case} $C = C_1[x]~[\rho]M$ s.t. $\Gamma, x{:}A \vdash  C_1[x]~M : B$ where $\Gamma \vdash M : B'$ and $\Gamma, x{:}A \ext{\rho} \Gamma$.
+%% \\[0.5em]
+%% Assume $\Gamma, y{:}A' \vdash C_1[C'[y]]~[\rho']M \red Q : B$ where $\Gamma, y{:}A' \ext{\rho'} \Gamma$.
 
-\paragraph{Sub-case} $\ianc{\Gamma, y{:}A' \vdash [\rho']M \red M' : B'}
-                          {\Gamma, y{:}A' \vdash C_1[C'[y]]~[\rho']M \red C_1[C'[y]]~M' : B}{}$ and $Q = C_1[C'[y]]~M' $
-\\[0.5em]
-$\Gamma, x{:}A \vdash C_1[x] : B' \arrow B \in \csn$ and $\Gamma, x{:}A \vdash [\rho]M : B' \in \csn$ \hfill by Lemma \ref{lem:psn} (Property \ref{pp6}) \\
-$\Gamma, y{:}A' \vdash C_1[~C'[y]~] : B' \arrow B \in \csn$ \hfill by IH \\
-$\Gamma \vdash M : B' \in \csn$ \hfill by Strengthening Lemma using
-$\Gamma, x{:}A \vdash [\rho]M : B' \in \csn$ (Lemma \ref{lm:strsn})\\
-$\Gamma, y{:}A' \vdash [\rho]M : B' \in \csn$ \hfill by Weakening Lemma for $\csn$ (Lemma \ref{lm:wksn})\\
-%
-$\Gamma, y{:}A' \vdash M' : B' \in \csn$ \hfill using $\Gamma, y{:}A' \vdash [\rho]M : B' \in \csn$ and $\Gamma, x{:}A' \vdash [\rho']M \red M' : B'$\\
-$\Gamma, y{:}A' \vdash C_1[~C'[y]~]~M' : B \in \csn$ \hfill using Lemma \ref{lm:closn} (Property \ref{cp3})\\
-$\Gamma, y{:}A' \vdash C_1[~C'[y]~]~[\rho']M$ \hfill since $\Gamma, y{:}A' \vdash C_1[C'[y]]~[\rho']M \red Q : B$ was arbitary.
+%% \paragraph{Sub-case} $\ianc{\Gamma, y{:}A' \vdash [\rho']M \red M' : B'}
+%%                           {\Gamma, y{:}A' \vdash C_1[C'[y]]~[\rho']M \red C_1[C'[y]]~M' : B}{}$ and $Q = C_1[C'[y]]~M' $
+%% \\[0.5em]
+%% $\Gamma, x{:}A \vdash C_1[x] : B' \arrow B \in \csn$ and $\Gamma, x{:}A \vdash [\rho]M : B' \in \csn$ \hfill by Lemma \ref{lem:psn} (Property \ref{pp6}) \\
+%% $\Gamma, y{:}A' \vdash C_1[~C'[y]~] : B' \arrow B \in \csn$ \hfill by IH \\
+%% $\Gamma \vdash M : B' \in \csn$ \hfill by Strengthening Lemma using
+%% $\Gamma, x{:}A \vdash [\rho]M : B' \in \csn$ (Lemma \ref{lm:strsn})\\
+%% $\Gamma, y{:}A' \vdash [\rho]M : B' \in \csn$ \hfill by Weakening Lemma for $\csn$ (Lemma \ref{lm:wksn})\\
+%% %
+%% $\Gamma, y{:}A' \vdash M' : B' \in \csn$ \hfill using $\Gamma, y{:}A' \vdash [\rho]M : B' \in \csn$ and $\Gamma, x{:}A' \vdash [\rho']M \red M' : B'$\\
+%% $\Gamma, y{:}A' \vdash C_1[~C'[y]~]~M' : B \in \csn$ \hfill using Lemma \ref{lm:closn} (Property \ref{cp3})\\
+%% $\Gamma, y{:}A' \vdash C_1[~C'[y]~]~[\rho']M$ \hfill since $\Gamma, y{:}A' \vdash C_1[C'[y]]~[\rho']M \red Q : B$ was arbitary.
 
-\paragraph{Sub-case} $\ianc{\ianc{\Gamma, y{:}A' \vdash C'[y] \red Q' : A}
-                                {\Gamma, y{:}A' \vdash C_1[C'[y]] \red C_1[Q'] : B' \arrow B}{}}
-                          {\Gamma, y{:}A' \vdash C_1[C'[y]]~[\rho']M \red C_1[Q]~[\rho']M : B}{}$
-\\[0.5em]
-$Q' = C''[y]$ where $C' = \underline{\quad}~N_1 \ldots N_i \ldots N_n$ and 
-$C'' = \underline{\quad}~N_1\ldots N'_i \ldots N_n$ where $\Gamma, y{:}A' \vdash N_i \red N'_i : B_i$
-\\
-$\Gamma, x{:}A \vdash C_1[x] : B' \arrow B \in \csn$ and $\Gamma, x{:}A \vdash [\rho]M : B' \in \csn$ \hfill by Lemma \ref{lem:psn} (Property \ref{pp6}) \\
-$\Gamma \vdash M : B' \in \csn$ \hfill by Strengthening Lemma using $\Gamma, x{:}A \vdash [\rho]M : B' \in \csn$\\
-$\Gamma, y{:}A' \vdash [\rho]M : B' \in \csn$ \hfill by Weakening Lemma \\
-$\Gamma, y{:}A' \vdash C''[y] : A \in \csn$ \hfill using $\Gamma, y{:}A' \vdash C'[y] : A \in \csn$\\
-$\Gamma, y{:}A' \vdash C_1[C''[y]] : B' \arrow B \in \csn$ \hfill by IH \\
-$\Gamma, y{:}A' \vdash C_1[C''[y]] ~[\rho']M  : B \in \csn$\hfill using Lemma \ref{lm:closn} (Property \ref{cp3})\\
-$\Gamma, y{:}A' \vdash C_1[C'[y]]~[\rho']M : B \in \csn$ \hfill by since $\Gamma, y{:}A' \vdash C_1[C'[y]]~[\rho']M \red Q : B$ was arbitrary
+%% \paragraph{Sub-case} $\ianc{\ianc{\Gamma, y{:}A' \vdash C'[y] \red Q' : A}
+%%                                 {\Gamma, y{:}A' \vdash C_1[C'[y]] \red C_1[Q'] : B' \arrow B}{}}
+%%                           {\Gamma, y{:}A' \vdash C_1[C'[y]]~[\rho']M \red C_1[Q]~[\rho']M : B}{}$
+%% \\[0.5em]
+%% $Q' = C''[y]$ where $C' = \underline{\quad}~N_1 \ldots N_i \ldots N_n$ and 
+%% $C'' = \underline{\quad}~N_1\ldots N'_i \ldots N_n$ where $\Gamma, y{:}A' \vdash N_i \red N'_i : B_i$
+%% \\
+%% $\Gamma, x{:}A \vdash C_1[x] : B' \arrow B \in \csn$ and $\Gamma, x{:}A \vdash [\rho]M : B' \in \csn$ \hfill by Lemma \ref{lem:psn} (Property \ref{pp6}) \\
+%% $\Gamma \vdash M : B' \in \csn$ \hfill by Strengthening Lemma using $\Gamma, x{:}A \vdash [\rho]M : B' \in \csn$\\
+%% $\Gamma, y{:}A' \vdash [\rho]M : B' \in \csn$ \hfill by Weakening Lemma \\
+%% $\Gamma, y{:}A' \vdash C''[y] : A \in \csn$ \hfill using $\Gamma, y{:}A' \vdash C'[y] : A \in \csn$\\
+%% $\Gamma, y{:}A' \vdash C_1[C''[y]] : B' \arrow B \in \csn$ \hfill by IH \\
+%% $\Gamma, y{:}A' \vdash C_1[C''[y]] ~[\rho']M  : B \in \csn$\hfill using Lemma \ref{lm:closn} (Property \ref{cp3})\\
+%% $\Gamma, y{:}A' \vdash C_1[C'[y]]~[\rho']M : B \in \csn$ \hfill by since $\Gamma, y{:}A' \vdash C_1[C'[y]]~[\rho']M \red Q : B$ was arbitrary
 
-\end{proof}
+%% \end{proof}
 
 
-\begin{lemma}\label{lem:appsnclosure}
+\begin{lemma}[Closure of strongly normalizing terms under $\beta$-expansion]\label{lem:appsnclosure}
 If $\Gamma, x{:}A \vdash M : B \in \csn$ and $\Gamma \vdash N : A \in \csn$
-and $\Gamma \vdash C[~[N/x]M~] : B \in \csn$ 
-and $\Gamma, x{:}B \vdash C[x] : B' \in \csn$
+and $\Gamma \vdash C[~[N/x]M~] : B' \in \csn$
+and $\Gamma \holetype B \vdash C : B' \in \csn$
 then $\Gamma \vdash C[\,(\lambda x.M)~N\,] : B' \in \csn$
 \end{lemma}
 \begin{proof}
-Proof by induction -- either $\Gamma, x{:}A \vdash M : B \in \csn$ is getting smaller,  
-$\Gamma \vdash N : A \in \csn$ is getting smaller, or 
-$\Gamma \vdash C[~[N/x]M~] : B \in \SN$  is getting smaller\ednote{In the Agda implementation, this lemma uses $\Gamma \vdash C[~[N/x]M~] : B \in \SN$ which means it cannot be proven independently; this does not make sense to me. Otherwise the proof follows the same main ideas. -bp}.
+Proof by induction -- either $\Gamma, x{:}A \vdash M : B \in \csn$ is getting smaller,
+$\Gamma \vdash N : A \in \csn$ is getting smaller, or
+$\Gamma \vdash C[~[N/x]M~] : B' \in \csn$  is getting smaller.
 \\[1em]
 \noindent
-Assume  $\Gamma \vdash C[(\lambda x.M)~N] \red P : B'$.
+Assume  $\Gamma \vdash C[(\lambda x.M)~N] \red P : B'$, we need to prove $\Gamma \vdash P : B' \in \csn$
+\\[1em]
+Either $\exists M'$ s.t. $P = C[M']$ and $\Gamma \vdash (\lambda x.M)~N \red M' : B$ \hfill by Lemma ~\ref{lm:invrectx}\\
+Or $\exists D$ s.t. $P = D[(\lambda x.M)~N]$, $\Gamma \holetype B \vdash D : B' \in \csn$
+           and $\forall N. \Gamma \vdash C[N] \red D[N] : B'$\\
 
-\paragraph{Case} $\ianc{\above{\D}{\Gamma \vdash (\lambda x.M)~N \red Q}}{\Gamma \vdash C[(\lambda x.M)~N] \red C[Q] : B'}{}$. i.e. we reduce in the head position.
+
+ \paragraph{Case} $\exists M'$ s.t. $P = C[M']$ and $\Gamma \vdash (\lambda x.M)~N \red M' : B$
 \\[0.5em]
-
-% \paragraph{Case} $\ianc{\Gamma \vdash (\lambda x.M)~N \red Q}{\Gamma \vdash C[(\lambda x.M)~N] \red C[Q] : B'}{}$.
-
- \paragraph{Sub-Case} 
-  $\D = \ianc {\Gamma \vdash \lambda x{:}A.M : A \arrow B 
-         \quad \Gamma \vdash  N : A}
-              {\Gamma \vdash (\lambda x{:}A.M)~N  \red [N/x]M : B }{}$ and $ Q = [N/x]M$
- \\
-$\Gamma \vdash C[~[N/x]M ~] \in \csn$ \hfill by assumption
-
-\paragraph{Sub-Case}
- $\D = \ianc {\ianc{\Gamma, x{:}A \vdash M \red M' : B}
-                   {\Gamma \vdash \lambda x{:}A.M \red \lambda x{:}A.M' : A \arrow B }{}
-        \quad \Gamma \vdash N : A}
-             {\Gamma \vdash (\lambda x{:}A.M)~N \red (\lambda x{:}A.M')~N : B}{}$ 
- and $Q = (\lambda x{:}A.M')~N$
+\textbf{Sub-Case} $\Gamma \vdash (\lambda x.M)~N \red [N/x]M$\\
+$\Gamma \vdash C[~[N/x]M~] : B \in \csn$ \hfill by assumption
 \\[0.5em]
-$\Gamma, x{:}A \vdash M' : B \in \csn$ \hfill using $\Gamma, x{:}A \vdash M : B \in \csn$\\
-$\Gamma \vdash N : A \in \csn$ \hfill by assumption \\
-$\Gamma, x{:}A \vdash C[x] : B' \in \csn$ \hfill by assumption \\
-$\Gamma \vdash [N/x]M \red [N/x]M' : B$ \hfill by Subst. Lemma for Typed Red\\
-$\Gamma \vdash C[~[N/x]M~] \red C[~[N/x]M'] : B'$ \hfill by congruence \\
-$\Gamma \vdash C[~[N/x]M'] : B' \in \csn$ \hfill by using $\Gamma \vdash C[~[N/x]M~] : B' \in \csn$ \\
-$\Gamma \vdash C[\, (\lambda x{:}A.M')~N\;] : B'$ \hfill by IH
-
-\paragraph{Sub-Case}
- $\D = \ianc {\Gamma \vdash \lambda x{:}A.M : A \arrow B 
-        \quad \Gamma \vdash N \red N' : A}
-             {\Gamma \vdash (\lambda x{:}A.M)~N \red (\lambda x{:}A.M)~N' : B}{}$
+\textbf{Sub-Case} $\ianc{\Gamma \vdash N \red N' : A}{\Gamma \vdash (\lambda x.M)~N \red (\lambda x.M)~N' : B}{}$\\
+$\Gamma \vdash N' : A \in \csn$ \hfill by $\Gamma \vdash N : A \in \csn$ and $\Gamma \vdash N \red N' : A \in \csn$\\
+$\Gamma \vdash [N/x]M \mred [N'/x]M : B$ \hfill by $\Gamma \vdash N \red N'$ and Lemma \ref{lm:mredprop}(\ref{lm:mredsubs})\\
+$\Gamma \vdash C[~[N'/x]M~] : B \in \csn$ \hfill by Lemmas \ref{lm:mredecxt} and \ref{lm:mredsn}\\
+$\Gamma \vdash C[~(\lambda x.M)~N'~] : B \in \csn$ \hfill by IH
 \\[0.5em]
-$\Gamma \vdash N' : A \in \csn$ \hfill using $\Gamma \vdash N : A \in \csn$\\
-$\Gamma \vdash \lambda x{:}A.M : A \arrow B$ \hfill by assumption \\
-$\Gamma, x{:}A \vdash M : B $ \hfill by inversion on typing\\
-$\Gamma \vdash [N/x]M \mred [N'/x]M : B$ \hfill by Lemma \ref{lm:mredprop}(\ref{lm:mredsubs}) using $\Gamma \vdash N \red N' : A$\\
-$\Gamma \vdash C[~[N/x]M~] \mred C[~[N'/x]M~] : B'$ \hfill by Multi-Step Red. on Eval. Ctx. (Lemma \ref{lm:mredecxt})\\
-$\Gamma \vdash C[~[N'/x]M] : B' \in \csn$ \hfill Lemma \ref{lm:mredsn} using $\Gamma \vdash C[~[N/x]M~] : B' \in \csn$\\
-$\Gamma, x{:}A \vdash M : B \in \csn$ \hfill by assumption \\
-$\Gamma, x{:}B \vdash C[x] : B' \in \csn$ \hfill by assumption \\
-$\Gamma \vdash C[~(\lambda x{:}A.M)~N'~] : B' \in \csn$ \hfill by IH % (since $\Gamma \vdash N' : A \in \csn$ is smaller)
+\textbf{Sub-Case} $\ianc{\Gamma, x{:}A \vdash M \red M' : B}{\Gamma \vdash (\lambda x.M)~N \red (\lambda x.M')~N : B}{}$\\
+$\Gamma, x{:}A \vdash M' : B \in \csn$ \hfill by $\Gamma, x{:}A \vdash M : B \in \csn$ and $\Gamma, x{:}A \vdash M \red M' : B$\\
+$\Gamma \vdash C[~[x/N]M~] \red C[~[x/N]M'~] : B'$ \hfill by Lemma \ref{lem:redsubst} and \ref{lm:pectx} (3)\\
+$\Gamma, x{:}A \vdash C[~[x/N]M'~] : B' \in \csn$ \hfill by $\Gamma \vdash C[~[N/x]M~] : B \in \csn$\\
+$\Gamma \vdash C[\,(\lambda x.M')~N\,] : B' \in \csn$ \hfill by IH
 
-\paragraph{Case} $\D = \Gamma \vdash C[~(\lambda x.M)~N~] \red C'[~(\lambda x.M)~N~]$, i.e. we reduce, but not in a head position; if $C = \underline{\quad}~N_0\ldots N_n$ and there is a reduction $\Gamma \vdash N_i \red N'_i : A_i$. Furthermore $C' = \underline{\quad}~N_0\ldots N'_i \ldots N_n$\footnote{I would prefer a more structural argument based on the structure of evaluation contexts, but this works for now. -bp}
-\\[0.5em]
-$\Gamma \vdash  C[~[N/x]M~] \red  C'[~[N/x]M~] : B'$ \hfill by given assumption \\
-$\Gamma \vdash C'[~[N/x]M~] : B' \in \csn$ \hfill using  $\Gamma \vdash C[~[N/x]M~] : B \in \csn$ 
-\\
-$\Gamma \vdash C'[\,(\lambda x.M)~N\,] : B' \in \csn$ \hfill by IH.
+\paragraph{Case} $\exists D$ s.t. $P = D[(\lambda x.M)~N]$, $\Gamma \holetype B \vdash D : B' \in \csn$
+           and $\forall N. \Gamma \vdash C[N] \red D[N] : B'$\\
+$\Gamma \vdash C[~[x/N]M~] \red D[~[x/N]M~] : B'$ \hfill by $\forall N. \Gamma \vdash C[N] \red D[N] : B'$\\
+$\Gamma \vdash D[~[x/N]M~] : B' \in \csn$ \hfill by $\Gamma \vdash C[~[N/x]M~] : B' \in \csn$\\
+$\Gamma \vdash D[[\,(\lambda x.M')~N\,] : B' \in \csn$ \hfill by IH
 
 \end{proof}
 

--- a/sn-proof/sn-proof.tex
+++ b/sn-proof/sn-proof.tex
@@ -1051,7 +1051,7 @@ $\Gamma \vdash C[~(\lambda x.M)~N'~] : B \in \csn$ \hfill by IH
 \textbf{Sub-Case} $\ianc{\Gamma, x{:}A \vdash M \red M' : B}{\Gamma \vdash (\lambda x.M)~N \red (\lambda x.M')~N : B}{}$\\
 $\Gamma, x{:}A \vdash M' : B \in \csn$ \hfill by $\Gamma, x{:}A \vdash M : B \in \csn$ and $\Gamma, x{:}A \vdash M \red M' : B$\\
 $\Gamma \vdash C[~[x/N]M~] \red C[~[x/N]M'~] : B'$ \hfill by Lemma \ref{lem:redsubst} and \ref{lm:pectx} (3)\\
-$\Gamma, x{:}A \vdash C[~[x/N]M'~] : B' \in \csn$ \hfill by $\Gamma \vdash C[~[N/x]M~] : B \in \csn$\\
+$\Gamma \vdash C[~[x/N]M'~] : B' \in \csn$ \hfill by $\Gamma \vdash C[~[N/x]M~] : B \in \csn$\\
 $\Gamma \vdash C[\,(\lambda x.M')~N\,] : B' \in \csn$ \hfill by IH
 
 \paragraph{Case} $\exists D$ s.t. $P = D[(\lambda x.M)~N]$, $\Gamma \holetype B \vdash D : B' \in \csn$


### PR DESCRIPTION
Giving typing rules for evaluation contexts and proving some results.

The crucial lemma is "Inversion of Reduction involving an Evaluation Context"
which makes it possible to have a very clean and independent proof of stability
of sn under beta-expansion.