### PR TITLE
[ soundness ] via direct backwards closure proof

### DIFF
--- a/sn-proof/sn-proof.tex
+++ b/sn-proof/sn-proof.tex
@@ -688,10 +688,10 @@ expression of type $A$. This relation is specified by the two following typing r
 
 \begin{lemma}[Properties of Typed Evaluation Contexts]\label{lm:pectx}$\;$
 \begin{enumerate}
-  \item If $\Gamma \holetype \alpha \vdash C : A$ and $\Gamma \vdash M : \alpha$ then $\Gamma \vdash C[M] : A$.
-  \item If $\Gamma \holetype \beta \vdash C : A$ and $\Gamma \holetype \alpha \vdash C' : \beta$ then
+  \item \label{lm:pectxcut} If $\Gamma \holetype \alpha \vdash C : A$ and $\Gamma \vdash M : \alpha$ then $\Gamma \vdash C[M] : A$.
+  \item \label{lm:pectxcomp} If $\Gamma \holetype \beta \vdash C : A$ and $\Gamma \holetype \alpha \vdash C' : \beta$ then
         $\Gamma \holetype \alpha \vdash C \circ C' : A$
-  \item If $\Gamma \holetype \alpha \vdash C : A$ and $\Gamma \vdash M \red N : \alpha$ then
+  \item \label {lm:pectxred} If $\Gamma \holetype \alpha \vdash C : A$ and $\Gamma \vdash M \red N : \alpha$ then
         $\Gamma \vdash C[M] \red C[N] : A$
 \end{enumerate}
 \end{lemma}
@@ -713,12 +713,12 @@ $\csn$ like so:
 
 \begin{lemma}[Properties of Strongly Normalizing Evaluation Contexts]\label{lm:psnectx}$\;$
   \begin{enumerate}
-  \item If $\Gamma \holetype \alpha \vdash C : A \in \csn$ and $x : A \in \Gamma$
+  \item \label{lm:psnectxcut} If $\Gamma \holetype \alpha \vdash C : A \in \csn$ and $x : A \in \Gamma$
     then $\Gamma \vdash C[x] : A \in \csn$
-  \item If $\Gamma \holetype \beta \vdash C : A \in \csn$
+  \item \label{lm:psnectxcomp} If $\Gamma \holetype \beta \vdash C : A \in \csn$
     and $\Gamma \holetype \alpha \vdash C' : \beta \in \csn$
     then $\Gamma \holetype \alpha \vdash C \circ C' : A \in \csn$
-  \item If $\Gamma \vdash C[M] : A \in \csn$ then $\Gamma \holetype \alpha \vdash C : A \in \csn$
+  \item \label{lm:invertectxcsn} If $\Gamma \vdash C[M] : A \in \csn$ then $\Gamma \holetype \alpha \vdash C : A \in \csn$
     and $\Gamma \vdash M : \alpha \in \csn$
   \end{enumerate}
 \end{lemma}
@@ -1100,8 +1100,13 @@ Hence this approach seems particularly amendable to mechanizing proofs.
 \multicolumn{1}{l}{\mbox{Strong head reduction}} \\[1em]
 \ianc{\Gamma \vdash N : A \in \SN \quad \Gamma, x{:}A \vdash M : B}{\Gamma \vdash (\lambda x.M)\;N \redSN [N/x]M : B}{} \qquad
 \ianc{\Gamma \vdash R \redSN R' : A \arrow B \quad \Gamma \vdash M : A}{\Gamma \vdash R\,M \redSN R'\,M : B}{}
+\\[1em]
+\multicolumn{1}{l}{\mbox{Strong Evaluation Contexts}} \\[1em]
+\ianc{}{\Gamma \holetype \alpha \vdash \hole : \alpha \in \SN}{} \qquad
+\ianc{\Gamma \holetype \alpha \vdash C : A \arrow B \in \SN \quad \Gamma \vdash M : A \in \SN}{\Gamma \holetype \alpha \vdash C\,M : B \in \SN}{}
 \end{array}
 \]
+
   \caption{Inductive definition of strongly normalizing terms}
   \label{fig:sn}
 \end{figure}
@@ -1268,6 +1273,14 @@ $\Gamma \vdash M~N : B \in \SN$ \hfill by conversion of $\SNe$ to $\SN$
 
 % \end{proof}
 
+\begin{lemma}[Inversion Lemma for $\SNe$]\label{lm:sneinvert}
+If $\Gamma \vdash M : A \in \SNe$ then there exists $\alpha$, $C$ and $x{:}\alpha \in \Gamma$ such that:
+$\Gamma \holetype \alpha \vdash C : A \in SN$ and $M = C[x]$.
+\end{lemma}
+\begin{proof}
+By induction on $\Gamma \vdash M : A \in \SNe$.
+\end{proof}
+
 
 We will use the extensionality of $\SN$ for function types in the proof of \CR1:
 
@@ -1305,7 +1318,6 @@ By induction on $\SN$
 
 We first define $\redsn$ (strong head reduction):
 
-
   \[
 \begin{array}{l}
 \infer{\Gamma \vdash (\lambda x.M)\;N \redsn [N/x]M : B}{\Gamma, x{:}A \vdash M : B \quad \Gamma \vdash N : A \in \csn }
@@ -1317,186 +1329,27 @@ We first define $\redsn$ (strong head reduction):
 
 It satisfies a few  key properties:
 
-% \begin{lemma}\label{lm:redsnred}
-% If $\Gamma \vdash M \redsn N : B$ then $\Gamma \vdash M \red N : B$.
-% \end{lemma}
-% \begin{proof}
-% Induction on the first derivation.  
-% \end{proof}
-
-\begin{lemma}\label{lm:bclosed}
-If $\Gamma \vdash N : A \in \csn$ and $\Gamma \vdash [N/x]M : B \in \csn$ 
-then $\Gamma \vdash (\lambda x{:}A.M)~N : B \in \csn$. 
+\begin{lemma}[Backwards closure of $\csn$ for strong-head reduction]\label{lm:backclosn}$\;$\\
+If $\Gamma \holetype A \vdash C : B$, $\Gamma \vdash M \redsn M' : A$
+and $\Gamma \vdash C[M'] : A \in \csn$
+then $\Gamma \vdash C[M] : A \in \csn$.
 \end{lemma}
 \begin{proof}
-The proof follows from the closure properties (Lemma \ref{lem:appsnclosure}) using the empty evaluation context. We prove it here directly as the generalization to evaluation contexts is not needed.
+By induction on $\Gamma \vdash M \redsn M' : A$.
+
+\paragraph{Case} $\ianc{\Gamma \vdash Q : T \in \csn}{\Gamma \vdash (\lambda x{:}T. P)\,Q \redsn [x/P]Q : A}{}$
 \\[1em]
-Proof by induction -- either $\Gamma, x{:}A \vdash M : B \in \csn$ is getting smaller,  
-$\Gamma \vdash N : A \in \csn$ is getting smaller, or 
-$\Gamma \vdash [N/x]M : B \in \SN$  is getting smaller.
+$\Gamma \holetype A \vdash C : B \in \csn$ and $\Gamma \vdash [x/Q]P : A \in \csn$ \hfill by Lemma \ref{lm:psnectx} (\ref{lm:invertectxcsn})\\
+$\Gamma, x{:}T \vdash P : A \in \csn$ \hfill by Lemma \ref{lem:psn} (\ref{pp3})\\
+$\Gamma \vdash C[(\lambda x{:}T. P)\,Q] : B \in \csn$ \hfill by Lemma \ref{lem:appsnclosure}
 
-Assume  $\Gamma \vdash (\lambda x.M)~N \red P : B'$.
-
-\paragraph{Case} 
-  $\D = \ianc {\Gamma \vdash \lambda x{:}A.M : A \arrow B 
-         \quad \Gamma \vdash  N : A}
-              {\Gamma \vdash (\lambda x{:}A.M)~N  \red [N/x]M : B }{}$ and $ Q = [N/x]M$
- \\
-$\Gamma \vdash [N/x]M : B \in \csn$ \hfill by assumption
-
-\paragraph{Case}
- $\D = \ianc {\ianc{\Gamma, x{:}A \vdash M \red M' : B}
-                   {\Gamma \vdash \lambda x{:}A.M \red \lambda x{:}A.M' : A \arrow B }{}
-        \quad \Gamma \vdash N : A}
-             {\Gamma \vdash (\lambda x{:}A.M)~N \red (\lambda x{:}A.M')~N : B}{}$ 
- and $Q = (\lambda x{:}A.M')~N$
-\\[0.5em]
-$\Gamma, x{:}A \vdash M' : B \in \csn$ \hfill using $\Gamma, x{:}A \vdash M : B \in \csn$\\
-$\Gamma \vdash N : A \in \csn$ \hfill by assumption \\
-% $\Gamma, x{:}A \vdash C[x] : B' \in \csn$ \hfill by assumption \\
-$\Gamma \vdash [N/x]M \red [N/x]M' : B$ \hfill by Subst. Lemma for Typed Red\\
-$\Gamma \vdash [N/x]M : B' \in \csn$ \hfill by using $\Gamma \vdash [N/x]M : B' \in \csn$ \\
-$\Gamma \vdash (\lambda x{:}A.M')~N : B$ \hfill by IH (since $\Gamma \vdash [N/x]M' : B \in \csn$ is smaller)
-
-\paragraph{Case}
- $\D = \ianc {\Gamma \vdash \lambda x{:}A.M : A \arrow B 
-        \quad \Gamma \vdash N \red N' : A}
-             {\Gamma \vdash (\lambda x{:}A.M)~N \red (\lambda x{:}A.M)~N' : B}{}$
-\\[0.5em]
-$\Gamma \vdash N' : A \in \csn$ \hfill using $\Gamma \vdash N : A \in \csn$\\
-$\Gamma \vdash \lambda x{:}A.M : A \arrow B$ \hfill by assumption \\
-$\Gamma, x{:}A \vdash M : B $ \hfill by inversion on typing\\
-$\C : \Gamma \vdash [N/x]M \mred [N'/x]M : B$ and $1 \leq \C$ \hfill by Lemma \ref{lm:mredprop}(\ref{lm:mredsubs}) using $\Gamma \vdash N \red N' : A$\\
-% $\Gamma \vdash [N/x]M \red Q : B$ and $\Gamma \vdash Q \mred [N'/x]M : B$ \hfill since $\C \geq 1$ and multi-step red.\\
-$\Gamma \vdash [N'/x]M : B' \in \csn$ \hfill Lemma \ref{lm:mredsn} using $\Gamma \vdash [N/x]M : B' \in \csn$\\
-$\Gamma, x{:}A \vdash M : B \in \csn$ \hfill by assumption \\
-$\Gamma \vdash (\lambda x{:}A.M)~N' : B' \in \csn$ \hfill by IH  (since $\Gamma \vdash N' : A \in \csn$ is smaller)
-  
-\end{proof}
-
-
-
-
-\begin{lemma}[Confluence $\csn$]\label{lm:confsn}$\;$
-If $\Gamma \vdash M \redsn N : A$ and $\Gamma \vdash M \red N' : A$
-  then either $N = N'$ or 
-  there $\exists Q$ s.t. $\Gamma \vdash N'  \redsn Q : A$
-        and $\Gamma \vdash N \mred Q$.
-\end{lemma}
-\begin{proof}
-By induction on    $\Gamma \vdash M \redsn N : A$.
-
-\paragraph{Case}
-$\D = \ianc{\Gamma \vdash N : A \in \csn \quad \Gamma, x{:}A \vdash M : B}{\Gamma \vdash (\lambda x.M)\;N \redsn [N/x]M : B}{}$
-\qquad
-$\ianc{\Gamma \vdash \lambda x{:}A.M : A \arrow B \quad \Gamma \vdash  N : A}
-      {\Gamma \vdash (\lambda x{:}A.M)~N  \red [N/x]M : B }{}$
+\paragraph{Case} $\ianc{\Gamma \vdash P \redsn P' : T \arrow A}{\Gamma \vdash P\,Q \redsn P'\,Q : A}{}$
 \\[1em]
-$[N/x]M : B = [N/x]M : B $ \hfill by reflexivity
-
-\paragraph{Case}
-$\D = \ianc{\Gamma \vdash N : A \in \csn \quad \Gamma, x{:}A \vdash M : B}{\Gamma \vdash (\lambda x.M)\;N \redsn [N/x]M : B}{}$
-\qquad
-$\ianc {\Gamma \vdash \lambda x{:}A.M \red \lambda x{:}A.M' : A \arrow B \quad \Gamma \vdash N : A}
-       {\Gamma \vdash (\lambda x{:}A.M)~N  \red (\lambda x{:}A.M')~N : B}{}$
-\\[0.5em]
-$\Gamma, x{:}A \vdash M \red M' : B$ \hfill by inversion \\[0.5em]
-WE SHOW: there exists a $Q$ s.t. $\Gamma \vdash (\lambda x{:}A.M')~N  \redsn Q : B$ and 
-                                 $\Gamma \vdash [N/x]M \mred Q : B$
-\\[0.5em]
-Let $Q = [N/x]M'$.  \\
-$\Gamma \vdash (\lambda x{:}A.M')~N \redsn [N/x]M' : B$ \hfill by def. of $\redsn$\\
-$\Gamma \vdash [N/x]M \red [N/x]M' : B$ \hfill by Subst. of typed red. (Lemma \ref{lem:redsubst})\\
-$\Gamma \vdash [N/x]M \mred [N/x]M' : B$ \hfill using def. of $\mred$ 
-
-\paragraph{Case}
-$\D = \ianc{\Gamma \vdash N : A \in \csn \quad \Gamma, x{:}A \vdash M : B}{\Gamma \vdash (\lambda x.M)\;N \redsn [N/x]M : B}{}$
-\qquad
-$\ianc {\Gamma \vdash N\red N' : A  \quad \Gamma \vdash \lambda x{:}A.M : A \arrow B}
-       {\Gamma \vdash (\lambda x{:}A.M)~N  \red (\lambda x{:}A.M)~N' : B }{}$
-\\[1em]
-WE SHOW: there exists a $Q$ s.t. $\Gamma \vdash (\lambda x{:}A.M)~N' \redsn Q : B$ and $\Gamma \vdash  [N/x]M \mred Q : B$\\[0.5em]
-Let $Q = [N'/x]M$.\\
-$\Gamma \vdash (\lambda x{:}A.M)~N' \redsn [N'/x]M : B$ \hfill by def. of $\redsn$\\
-$\Gamma \vdash [N/x]M \mred [N'/x]M : B $ \hfill by Lemma \ref{lm:mredprop}(\ref{lm:mredsubs}) with $\Gamma \vdash N\red N' : A$ and $\Gamma, x{:}A \vdash M : B$
-
-\paragraph{Case}
-$\D  = \ianc{\Gamma \vdash M \redsn M_1 : A \arrow B \quad \Gamma \vdash N : A}
-            {\Gamma \vdash M\;N \redsn M_1\;N : B}{}$ 
-\qquad
-$\ianc {\Gamma \vdash M \red M_2 : A \arrow B \quad \Gamma \vdash N : A}
-       {\Gamma \vdash M~N  \red M_2~N : B}{}$
-\\[1em]
-Either $M_2 = M_1$ or there exists a $P$ s.t. $\Gamma \vdash M_2 \redsn P : A \arrow B$ and $\Gamma \vdash M_1 \mred P : A \arrow B$ \hfill by IH 
-
-\paragraph{Sub-case}$M_2 = M_1$
-\\[0.5em]
-$M_1~N = M_2~N$ \hfill trivial
-
-
-\paragraph{Sub-case} there exists a $P$ s.t. $\Gamma \vdash M_2 \redsn P : A \arrow B$ and $\Gamma \vdash M_1 \mred P : A \arrow B$\\[1em]
-WE SHOW: there exists a $Q$ s.t. $\Gamma \vdash M_2~N \redsn Q : B$ and $\Gamma \vdash  M_1\;N \mred Q : B$
-\\[0.5em]
-Let $Q = P~N$\\[0.5em]
-$\Gamma \vdash M_2~N \redsn P~N : B$ \hfill using def. of $\redsn$ and $\Gamma \vdash M_2 \redsn P : A \arrow B$\\
-$\Gamma \vdash M_1\;N \mred P~N : B$ \hfill using Lemma \ref{lm:mredprop} (\ref{lm:mredappl}) on multi-step red. and $\Gamma \vdash M_1 \mred P : A \arrow B$
-
-
-
-\paragraph{Case}
-$\D  = \ianc{\Gamma \vdash M \redsn M' : A \arrow B \quad \Gamma \vdash N : A}
-            {\Gamma \vdash M\;N \redsn M'\;N : B}{}$ 
-\qquad
-$\ianc {\Gamma \vdash N\red N' : A  \quad \Gamma \vdash M : A \arrow B}
-       {\Gamma \vdash M~N  \red M~N' : B }{}$
-\\[1em]
-WE SHOW: there exists a $Q$ s.t. $\Gamma \vdash M~N' \redsn Q : B$ and $\Gamma \vdash M'\;N \mred Q : B$
-\\[0.5em]
-Let $Q = M'~N'$ \\[0.5em]
-$\Gamma \vdash M~N' \redsn M'~N' : B$ \hfill by $\Gamma \vdash M \redsn M' : A \arrow B$ \\
-$\Gamma \vdash \vdash N\mred N' : A$ \hfill by rule for $\mred$\\
-$\Gamma \vdash M'~N \mred M'~N' : B$ \hfill by Multi-Step Reduction (Lemma \ref{lm:mredprop})(\ref{lm:mredappr}))
-
-\end{proof}
-
-
-
-\begin{lemma}[Backward closure of $\csn$]\label{lm:backclosn}$\;$
-\\
- If $\Gamma \vdash M \redsn M' : A$ and $\Gamma \vdash M' : A \in \csn$ then
-     $\Gamma \vdash M : A \in \csn$.
-\end{lemma}
-\begin{proof}
-By induction on    $\Gamma \vdash M \redsn M' : A$.
-
-\paragraph{Case}
-$\D = \ianc{\Gamma \vdash N : A \in \csn \quad \Gamma, x{:}A \vdash M : B}{\Gamma \vdash (\lambda x.M)\;N \redsn [N/x]M : B}{}$
-\\[1em]
-$\Gamma \vdash  [N/x]M : B \in \csn$ \hfill by assumption \\
-$\Gamma \vdash N : A \in \csn $ \hfill by assumption \\
-$\Gamma \vdash (\lambda x{:}A.M)~N : B \in \csn$ \hfill by Lemma \ref{lm:bclosed}
-
-
-\paragraph{Case}
-$\D = \ianc{\Gamma \vdash M \redsn M' : A \arrow B \quad \Gamma \vdash N : A}{\Gamma \vdash M\,N \redsn M'\,N : B}{}$
-\\[1em]
-$\Gamma \vdash M'~N : B \in \csn$ \hfill by assumption \\
-$\Gamma \vdash M' : A \arrow B \in \csn$ \hfill by Lemma \ref{lem:psn}(Prop. \ref{pp6})\\
-$\Gamma \vdash M : A \arrow B \in \csn$ \hfill by IH \\[0.5em]
-Assume $\Gamma \vdash M~N \red Q : B$ \\
-Either $Q = M'~N$ or $\exists P$ s.t. $\Gamma \vdash Q \redsn P : B$ and $\Gamma \vdash M'~N \mred P : B$ where we take at least one step (i.e. $P \not = M'~N$) \hfill by Conf. Lemma \ref{lm:confsn} 
-
-\paragraph{Sub-case} $Q = M'~N$ \\
-$\Gamma \vdash Q : B \in \csn$ \hfill by assumption $\Gamma \vdash M'~N : B \in \csn$
-% TO SHOW $\Gamma \vdash Q : B \in \csn$
-
-{\color{red}{\paragraph{Sub-case} $\exists P$ s.t. $\Gamma \vdash Q \redsn P : B$ and $\Gamma \vdash M'~N \mred P : B$\\[0.5em]
-$\C : \Gamma \vdash P : B \in \csn$ and $\C < \D$ \hfill using $\D : \Gamma \vdash M'~N : B \in \csn$ and Lemma \ref{lm:mredsn}
-\\
-$\Gamma \vdash Q : B \in \csn$  \hfill by IH using $\C : \Gamma \vdash P : B \in \csn$ and $\Gamma \vdash Q \redsn P : B$
-}}
-
-
+$\Gamma \holetype T \arrow A \vdash C \circ (\hole\,Q) : B$ \hfill by Lemma \ref{lm:pectx} (\ref{lm:pectxcomp})\\
+$\Gamma \vdash P \redsn P' : T \arrow A$ \hfill by assumption\\
+$\Gamma \vdash (C \circ (\hole \,Q))[P'] : A \in \csn$ \hfill by assumption\\
+$\Gamma \vdash (C \circ (\hole \,Q))[P] : A \in \csn$ \hfill by IH\\
+Therefore $\Gamma \vdash C[P\,Q] : A \in \csn$
 
 \end{proof}
 
@@ -1505,9 +1358,8 @@ $\Gamma \vdash Q : B \in \csn$  \hfill by IH using $\C : \Gamma \vdash P : B \in
 \mbox{}
   \begin{enumerate}
   \item If $\Gamma \vdash M : A \in \SN$ then $\Gamma \vdash M : A \in \csn$.
-  \item If $\Gamma \vdash C[x] : A \in \SNe$ then $\Gamma \vdash C[x] : A \in \csn$.
-   \item If $\Gamma \vdash M \redSN M' : A$ then
-           $\Gamma \vdash M \redsn M' : A$.
+  \item If $\Gamma \holetype \alpha \vdash C : A \in \SN$ then $\Gamma \holetype \alpha \vdash C : A \in \csn$.
+   \item If $\Gamma \vdash M \redSN M' : A$ then $\Gamma \vdash M \redsn M' : A$.
   \end{enumerate}
 \end{theorem}
 \begin{proof}
@@ -1518,8 +1370,9 @@ closure properties. \\[1em]
 
 \paragraph{Case} $\D = \ianc{\Gamma \vdash R : A \in \SNe}{\Gamma \vdash R : A \in \SN}{}$
 \\[1em]
-$R = C[x] $ \hfill since $\Gamma \vdash R : A \in \SNe$ \\
-$\Gamma \vdash R : A \in \csn$ \hfill by IH(1)
+$R = C[x]$ where $\Gamma \holetype \alpha \vdash A \in \SN$ and $x{:}A \in \Gamma$ \hfill by Lemma \ref{lm:sneinvert}\\
+$\Gamma \holetype \alpha \vdash A \in \csn$ \hfill by IH (2)\\
+$\Gamma \vdash C[x] : A \in \csn$ \hfill by Lemma \ref{lm:psnectx} (\ref{lm:psnectxcut})
 
 \paragraph{Case} $\D = \ianc{\Gamma, x{:}A \vdash M : B \in \SN}
                            {\Gamma  \vdash \lambda x{:}A.M  : A \arrow B \in \SN}{}$
@@ -1532,29 +1385,22 @@ $\Gamma \vdash \lambda x{:}A.M : A \arrow B \in \csn$ \hfill by  Property \ref{l
                             {\Gamma \vdash M  : A \in \SN}{} $
 \\[1em]
 $\Gamma \vdash M' : A \in \csn$ \hfill by IH(1)\\
-$\Gamma \vdash M : A \in \csn$ \hfill by IH (3) using the empty evaluation context and Lemma \ref{lm:closn}(\ref{cp2})
-% $\Gamma \vdash M \redsn M' : A$ \hfill by IH(3)\\
-% {\color{red}{$\Gamma \vdash M  : A \in \csn$ \hfill by Closure Property \ref{lm:closn}(\ref{cp5}) -- should be proven differently without using $\redsn$}}
+$\Gamma \vdash M \redsn M' : A$ \hfill by IH(3)\\
+$\Gamma \vdash M : A \in \csn$ \hfill by Lemma \ref{lm:backclosn}
 \\[1em]
 \noindent
-\fbox{2. If $\Gamma \vdash C[x] : A \in \SNe$ then $\Gamma \vdash C[x] : A \in \csn$.}
+\fbox{2. If $\Gamma \holetype \alpha \vdash C : A \in \SN$ then $\Gamma \holetype \alpha \vdash C : A \in \csn$.}
 
-\paragraph{Case} $\D = \ianc{x{:}A \in \Gamma}{\Gamma \vdash x : A \in \SNe}{}$
+\paragraph{Case} $\D = \Gamma \holetype \alpha \vdash \hole : \alpha \in \SN$
 \\[1em]
-$C = \_ $ \hfill since $C[x] = x$\\
-$\forall M'.~\Gamma \vdash x \red M' : A \imply \Gamma \vdash M' : A \in \csn$ \hfill since $\Gamma \vdash x \red M' : A$ is impossible
-\\
-$\Gamma \vdash x \in \csn$
+$\Gamma \holetype \alpha \vdash \hole : \alpha \in \csn$ \hfill by definition
 
-\paragraph{Case}$\D = \ibnc{\Gamma \vdash R : A \arrow B \in \SNe}{\Gamma \vdash M : A \in \SN}{\Gamma \vdash R\,M : B \in \SNe}{}$
-\\
-$C'[x] = R$ \hfill since $C[x] = R\;M$\\
-$\Gamma \vdash C'[x] : A \arrow B\in \csn$ \hfill by IH(2) \\
-$\Gamma \vdash M : A \in \csn$ \hfill by IH(1)\\
-$\Gamma \vdash C'[x]\;M : B \in \csn$ \hfill by Closure Property \ref{lm:closn}(\ref{cp3})\\
-$\Gamma \vdash C[x] : A \arrow B \in \csn$ \hfill since $C[x] = C'[x]~M$
+\paragraph{Case}$\D = \ibnc{\Gamma \holetype \alpha \vdash C : A \arrow B \in \SN}{\Gamma \vdash M : A \in SN}{\Gamma \holetype \alpha \vdash C\,M : B \in \SN}{}$\\
+$\Gamma \holetype \alpha \vdash C : A \arrow B \in \csn$ \hfill by IH (2)\\
+$\Gamma \vdash M : A \in \csn$ \hfill by IH (1)\\
+$\Gamma \holetype \alpha \vdash C\,M : B \in \csn$ \hfill by definition
 \\[1em]
-
+\noindent
 \fbox{3. If $\Gamma \vdash M \redSN M' : A$ then
            $\Gamma \vdash M \redsn M' : A$.}
 


### PR DESCRIPTION
No need for confluence of \red and \redsn because closure under
\beta-expansion and evaluation context manipulation tells us
everything we need to know.

Worth considering whether it'd make sense to redefine SNe directly
as variable + SN evaluation context: it'd save on the inversion
lemma.